### PR TITLE
Address duplicate token rows

### DIFF
--- a/src/server/controllers/auth-controller.js
+++ b/src/server/controllers/auth-controller.js
@@ -12,12 +12,9 @@ AuthController.post('', (req, res) => {
     .then((user) => {
       if (compareSync(password, user.passwordDigest)) {
         const value = uid(TOKEN_LENGTH)
-        const unsavedToken = Token.build({value})
-        unsavedToken.setUser(user)
-        unsavedToken.save()
-                    .then((token) => {
-                      res.json(token)
-                    })
+        Token.create({value})
+             .then((token) => token.setUser(user))
+             .then((token) => res.json(token))
       } else {
         res.status(401).json({
           error: {


### PR DESCRIPTION
Fixes an issue where creating a new token would create two rows in the database.

@NeverGoStable/owners I am going to go ahead and merge this hotfix. Hope that's alright with everyone.