### PR TITLE
Add routing to web

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "react-dom": "^0.14.0-rc1",
     "react-native": "^0.10.1",
     "react-redux": "^3.0.1",
+    "react-router": "^1.0.0-rc1",
     "redux": "^3.0.2",
+    "redux-router": "^1.0.0-beta3",
     "redux-thunk": "^1.0.0",
     "sequelize": "^3.9.0",
     "uid2": "0.0.3"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^0.6.0",
     "bcryptjs": "^2.2.2",
     "body-parser": "^1.13.3",
+    "history": "^1.11.1",
     "pg": "^4.4.2",
     "pg-hstore": "^2.3.2",
     "react": "^0.14.0-rc1",

--- a/src/actions/token.js
+++ b/src/actions/token.js
@@ -1,5 +1,5 @@
+import { pushState } from 'redux-router'
 import api from 'utils/api'
-
 import { REQUEST_TOKEN, RECEIVE_TOKEN } from 'constants/action-types'
 
 function requestLogin() {
@@ -20,7 +20,12 @@ export function fetchAuthToken(email, password) {
     dispatch(requestLogin())
     api.post('/auth', {email, password})
        .then((resp) => resp.data.value)
-       .then((token) => dispatch(receiveToken(token)))
+       .then((token) => [
+         receiveToken(token),
+         pushState({}, '/home')
+       ].map(dispatch))
        .catch((err) => console.log(err))
   }
 }
+
+window.pushState = pushState

--- a/src/actions/token.js
+++ b/src/actions/token.js
@@ -22,7 +22,7 @@ export function fetchAuthToken(email, password) {
        .then((resp) => resp.data.value)
        .then((token) => [
          receiveToken(token),
-         pushState({}, '/home')
+         pushState({}, '/home'),
        ].forEach(dispatch))
        .catch((err) => console.log(err))
   }

--- a/src/actions/token.js
+++ b/src/actions/token.js
@@ -23,7 +23,7 @@ export function fetchAuthToken(email, password) {
        .then((token) => [
          receiveToken(token),
          pushState({}, '/home')
-       ].map(dispatch))
+       ].forEach(dispatch))
        .catch((err) => console.log(err))
   }
 }

--- a/src/actions/token.js
+++ b/src/actions/token.js
@@ -27,5 +27,3 @@ export function fetchAuthToken(email, password) {
        .catch((err) => console.log(err))
   }
 }
-
-window.pushState = pushState

--- a/src/components/web/app.web.js
+++ b/src/components/web/app.web.js
@@ -16,7 +16,7 @@ export default class App extends Component {
   }
 
   componentWillMount() {
-    if (!this.props.token) this.props.pushState({}, '/signup')
+    if (!this.props.token) this.props.pushState({}, '/login')
   }
 
   render() {

--- a/src/components/web/app.web.js
+++ b/src/components/web/app.web.js
@@ -9,6 +9,8 @@ import { pushState } from 'redux-router'
 export default class App extends Component {
 
   static propTypes = {
+    token: PropTypes.object,
+    pushState: PropTypes.func.isRequired,
     children: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.arrayOf(PropTypes.element),

--- a/src/components/web/app.web.js
+++ b/src/components/web/app.web.js
@@ -2,9 +2,15 @@ import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { pushState } from 'redux-router'
 
+function mapStateToProps(state) {
+  return state.token
+}
+
+const mapDispatchToProps = { pushState }
+
 @connect(
-  (state) => state.token,
-  { pushState }
+  mapStateToProps,
+  mapDispatchToProps
 )
 export default class App extends Component {
 

--- a/src/components/web/app.web.js
+++ b/src/components/web/app.web.js
@@ -1,5 +1,11 @@
 import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
+import { pushState } from 'redux-router'
 
+@connect(
+  (state) => state.token,
+  { pushState }
+)
 export default class App extends Component {
 
   static propTypes = {
@@ -7,6 +13,10 @@ export default class App extends Component {
       PropTypes.element,
       PropTypes.arrayOf(PropTypes.element),
     ]),
+  }
+
+  componentWillMount() {
+    if (!this.props.token) this.props.pushState({}, '/signup')
   }
 
   render() {

--- a/src/components/web/app.web.js
+++ b/src/components/web/app.web.js
@@ -1,14 +1,18 @@
-import React, { Component } from 'react'
-
-import SignupForm from 'components/web/signup-form'
-import LoginForm from 'components/web/login-form'
+import React, { Component, PropTypes } from 'react'
 
 export default class App extends Component {
+
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.arrayOf(PropTypes.element),
+    ]),
+  }
+
   render() {
     return (
       <div>
-        <SignupForm />
-        <LoginForm />
+        {this.props.children}
       </div>
     )
   }

--- a/src/components/web/app.web.js
+++ b/src/components/web/app.web.js
@@ -9,7 +9,7 @@ import { pushState } from 'redux-router'
 export default class App extends Component {
 
   static propTypes = {
-    token: PropTypes.object,
+    token: PropTypes.string,
     pushState: PropTypes.func.isRequired,
     children: PropTypes.oneOfType([
       PropTypes.element,

--- a/src/components/web/home-page.js
+++ b/src/components/web/home-page.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react'
+
+export default class HomePage extends Component {
+  render() {
+    return (
+      <div>
+        <h1>Hello!</h1>
+        <p>You are now signed in as {this.props.currentUser && this.props.currentUser.fullName}</p>
+      </div>
+    )
+  }
+}

--- a/src/components/web/home-page.js
+++ b/src/components/web/home-page.js
@@ -1,6 +1,11 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes } from 'react'
 
 export default class HomePage extends Component {
+
+  static propTypes = {
+    currentUser: PropTypes.object,
+  }
+
   render() {
     return (
       <div>

--- a/src/components/web/home-page.js
+++ b/src/components/web/home-page.js
@@ -5,6 +5,11 @@ export default class HomePage extends Component {
     return (
       <div>
         <h1>Hello!</h1>
+        {
+         // TODO: actually store `currentUser` in the store.
+         // probably a good idea to modify the auth endpoint
+         // to return both the token and currentUser object
+        }
         <p>You are now signed in as {this.props.currentUser && this.props.currentUser.fullName}</p>
       </div>
     )

--- a/src/components/web/login-form.web.js
+++ b/src/components/web/login-form.web.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { Link } from 'react-router'
 
-import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 
 import { fetchAuthToken } from 'actions/token'

--- a/src/components/web/login-form.web.js
+++ b/src/components/web/login-form.web.js
@@ -6,13 +6,15 @@ import { connect } from 'react-redux'
 
 import { fetchAuthToken } from 'actions/token'
 
+function mapStateToProps(state) {
+  return state.token
+}
+
+const mapDispatchToProps = { login: fetchAuthToken }
+
 @connect(
-  (state) => state.token,
-  (dispatch) =>
-      bindActionCreators(
-        { login: fetchAuthToken },
-        dispatch
-      )
+  mapStateToProps,
+  mapDispatchToProps,
 )
 export default class LoginForm extends Component {
 

--- a/src/components/web/login-form.web.js
+++ b/src/components/web/login-form.web.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react'
+import { Link } from 'react-router'
 
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
@@ -45,21 +46,24 @@ export default class LoginForm extends Component {
 
   render() {
     return (
-      <form onSubmit={this.handleSubmit}>
-        <div>
-          <input onChange={this.handleInputChange('email')}
-                 placeholder="Email"
-                 value={this.state.email}
-                 type="email" />
-        </div>
-        <div>
-          <input onChange={this.handleInputChange('password')}
-                 placeholder="Password"
-                 value={this.state.password}
-                 type="password" />
-        </div>
-        <button type="submit">Login</button>
-      </form>
+      <div>
+        <form onSubmit={this.handleSubmit}>
+          <div>
+            <input onChange={this.handleInputChange('email')}
+                   placeholder="Email"
+                   value={this.state.email}
+                   type="email" />
+          </div>
+          <div>
+            <input onChange={this.handleInputChange('password')}
+                   placeholder="Password"
+                   value={this.state.password}
+                   type="password" />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+        <Link to="/signup">Don't have an account yet?</Link>
+      </div>
     )
   }
 }

--- a/src/components/web/signup-form.web.js
+++ b/src/components/web/signup-form.web.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Link } from 'react-router'
 
 import api from 'utils/api'
 
@@ -43,32 +44,34 @@ export default class SignupForm extends Component {
 
   render() {
     return (
-      <form onSubmit={this.handleSubmit}>
-        <h4>Create an account</h4>
-        <div>
-          <input onChange={this.handleInputChange('fullName')}
-                 value={this.state.fullName}
-                 type="text"
-                 placeholder="Full Name"/>
-        </div>
-        <div>
-          <input onChange={this.handleInputChange('email')}
-                 value={this.state.email}
-                 type="email"
-                 placeholder="Email"/>
-        </div>
-        <div>
-          <input onChange={this.handleInputChange('password')}
-                 value={this.state.password}
-                 type="password"
-                 placeholder="Password"/>
-        </div>
-        <button type="submit"
-                disabled={this.isFormDisabled()} >
-          Submit
-        </button>
-        <pre>{JSON.stringify(this.state.resp && this.state.resp.data)}</pre>
-      </form>
+      <div>
+        <form onSubmit={this.handleSubmit}>
+          <h4>Create an account</h4>
+          <div>
+            <input onChange={this.handleInputChange('fullName')}
+                   value={this.state.fullName}
+                   type="text"
+                   placeholder="Full Name"/>
+          </div>
+          <div>
+            <input onChange={this.handleInputChange('email')}
+                   value={this.state.email}
+                   type="email"
+                   placeholder="Email"/>
+          </div>
+          <div>
+            <input onChange={this.handleInputChange('password')}
+                   value={this.state.password}
+                   type="password"
+                   placeholder="Password"/>
+          </div>
+          <button type="submit"
+                  disabled={this.isFormDisabled()} >
+            Submit
+          </button>
+        </form>
+        <Link to="/login">Already have an account?</Link>
+      </div>
     )
   }
 }

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -5,10 +5,12 @@ import { Route } from 'react-router'
 import App from 'components/web/app'
 import LoginForm from 'components/web/login-form'
 import SignupForm from 'components/web/signup-form'
+import HomePage from 'components/web/home-page'
 
 export default (
   <Route path="/" component={App}>
     <Route path="/login" component={LoginForm} />
     <Route path="/signup" component={SignupForm} />
+    <Route path="/home" component={HomePage} />
   </Route>
 )

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,0 +1,14 @@
+import React from 'react'
+
+import { Route } from 'react-router'
+
+import App from 'components/web/app'
+import LoginForm from 'components/web/login-form'
+import SignupForm from 'components/web/signup-form'
+
+export default (
+  <Route path="/" component={App}>
+    <Route path="/login" component={LoginForm} />
+    <Route path="/signup" component={SignupForm} />
+  </Route>
+)

--- a/src/main.web.js
+++ b/src/main.web.js
@@ -4,13 +4,17 @@ import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import configureStore from 'store/configure-store'
 
-import App from 'components/web/app'
+import { ReduxRouter } from 'redux-router'
+import routes from 'constants/routes'
+
 
 const store = configureStore()
 
 ReactDOM.render(
   <Provider store={store}>
-    <App />
+    <ReduxRouter>
+      {routes}
+    </ReduxRouter>
   </Provider>,
   document.getElementById('main')
 )

--- a/src/reducers/root-reducer.js
+++ b/src/reducers/root-reducer.js
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux'
 
+import { routerStateReducer } from 'redux-router'
 import token from 'reducers/token'
 
 const rootReducer = combineReducers({
   token,
+  router: routerStateReducer,
 })
 
 export default rootReducer

--- a/src/store/configure-store.js
+++ b/src/store/configure-store.js
@@ -1,17 +1,24 @@
-import { createStore, applyMiddleware } from 'redux'
+import { compose, createStore, applyMiddleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
+
+import { reduxReactRouter } from 'redux-router'
+import createHistory from 'history/lib/createBrowserHistory'
+import routes from 'constants/routes'
+
 import rootReducer from 'reducers/root-reducer'
 
-const loggerMiddleware = createLogger()
-
-const createStoreWithMiddleware = applyMiddleware(
-  thunkMiddleware,
-  loggerMiddleware,
-)(createStore)
-
 export default function configureStore(initialState = {}) {
-  const store = createStoreWithMiddleware(rootReducer, initialState)
+  const store = compose(
+    applyMiddleware(
+      thunkMiddleware,
+      createLogger(),
+    ),
+    reduxReactRouter({
+      routes,
+      createHistory,
+    })
+  )(createStore)(rootReducer, initialState)
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers


### PR DESCRIPTION
#### What's this do?

Adds client side routing using:
* `react-router`
* `redux-router`
* `rackt/history`

Currently it will redirect to login if you don't have a saved auth token. Once you've logged in, you're redirected to a placeholder `/home`

#### Why are we doing this?

We need a way to dynamically show content based on atomic app state.

#### Who should review this PR?

EVERYONE! @wilsonmct55 @tm507211 @joeyliu2012 @ak493812 

#### Screenshots (if applicable)

![image](https://cloud.githubusercontent.com/assets/1699281/10194417/8f38dd06-6756-11e5-8328-c32b344e7e47.png)

![image](https://cloud.githubusercontent.com/assets/1699281/10194405/8723eb2e-6756-11e5-90ab-d606dc8641a3.png)

![image](https://cloud.githubusercontent.com/assets/1699281/10194431/9e794d5a-6756-11e5-8edc-69d924b77fca.png)

